### PR TITLE
Skyfix

### DIFF
--- a/cubefit/main.py
+++ b/cubefit/main.py
@@ -262,6 +262,7 @@ def cubefit(argv=None):
         spectra[j] = np.interp(wave, bins[:-1] + np.diff(bins)[0]/2., 
                                mean_spec)
     mean_gal_spec = np.average(spectra, axis=0)
+    # Ensure that there won't be any negative or tiny values in mean:
     mean_floor = 0.1 * np.median(mean_gal_spec)
     mean_gal_spec[mean_gal_spec < mean_floor] = mean_floor
 

--- a/cubefit/main.py
+++ b/cubefit/main.py
@@ -12,6 +12,7 @@ import logging
 import math
 import os
 
+import scipy.stats
 import numpy as np
 
 from .version import __version__
@@ -255,8 +256,14 @@ def cubefit(argv=None):
     # Calculate rough average galaxy spectrum from all final refs.
     spectra = np.zeros((len(refs), len(wave)), dtype=np.float64)
     for j, i in enumerate(refs):
-        spectra[j] = np.average(cubes[i].data, axis=(1, 2)) - skys[i]
+        avg_spec = np.average(cubes[i].data, axis=(1, 2)) - skys[i]
+        mean_spec, bins, bn = scipy.stats.binned_statistic(wave, avg_spec, 
+                                                           bins=len(wave)/10)
+        spectra[j] = np.interp(wave, bins[:-1] + np.diff(bins)[0]/2., 
+                               mean_spec)
     mean_gal_spec = np.average(spectra, axis=0)
+    mean_floor = 0.1 * np.median(mean_gal_spec)
+    mean_gal_spec[mean_gal_spec < mean_floor] = mean_floor
 
     galprior = np.zeros((nw, MODEL_SHAPE[0], MODEL_SHAPE[1]), dtype=np.float64)
 

--- a/cubefit/utils.py
+++ b/cubefit/utils.py
@@ -132,7 +132,7 @@ def fft_shift_phasor(n, d, grad=False):
 
     # This is where we set the Nyquist frequency to be purely real (see above)
     if n % 2 == 0:
-        result[n/2] = np.real(result[n/2])
+        result[int(n/2)] = np.real(result[int(n/2)])
 
     if grad:
         df = 2. * np.pi * fft.fftfreq(n)


### PR DESCRIPTION
This fix resolves the issue in which the mean galaxy spectrum can go negative, leading to spikes in the regularization penalty. It also smooths the mean galaxy spectrum, so that the size of the regularization is less affected by noise.